### PR TITLE
Add missing CFBundleVersion to Info.plist

### DIFF
--- a/IntelliGist.app/Contents/Info.plist
+++ b/IntelliGist.app/Contents/Info.plist
@@ -8,16 +8,18 @@
 	<string>IntelliGist</string>
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
-	<key>CFBundleIdentifier</key>
-	<string>IntelliGist</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.intelligist.app</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>IntelliGist</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.0.0</string>
+        <key>CFBundleShortVersionString</key>
+        <string>0.0.0</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Summary
- fix macOS bundle metadata by adding the required CFBundleVersion and using a reverse-DNS bundle identifier

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689163e483188320a56d30a6b0e7eb7d